### PR TITLE
Add permission to config

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -3,7 +3,7 @@ import * as fs from "fs";
 import mime from 'mime-types'
 const Eos = require('eosjs')
 import { splitString } from './utils'
-import { maxPayloadSize, chainId, from, wif } from './costants'
+import { maxPayloadSize, chainId, from, wif, permission } from './costants'
 
 const config = {
   chainId: chainId,
@@ -30,7 +30,7 @@ export function doTx(memo: string): Promise<any> {
       // })
 
       const options = {
-        authorization: [`${from}@active`]
+        authorization: [`${from}@${permission}`]
       }
       eos.contract('decentwitter').then((contract: any) => {
         contract.avatar(memo, options).then((res:any) => {

--- a/src/costants.ts
+++ b/src/costants.ts
@@ -9,7 +9,8 @@ function loadConfig() {
     fs.writeFileSync(`${confDir}/config.json`, `
 {
   "from":"",
-  "privateKey":""
+  "privateKey":"",
+  "permssion":"active"
 }
     `)
     console.log(`eosfilestore: Generated '${confDir}/config.json', please edit with your EOS keys`)
@@ -31,3 +32,4 @@ export const costPerTx = 0.0001
 export const chainId = confObj.chainId || 'aca376f206b8fc25a6ed44dbdc66547c36c6c33e3a119ffbeaef943642f0e906' // mainnet
 export const wif = confObj.privateKey
 export const from = confObj.from
+export const permission = confObj.permission || 'active'


### PR DESCRIPTION
Add the ability to change your permission, that way you can setup a "throw away" private key for EOSfilestore.

## How to setup permission

```
$ cleos set account permission <ACCOUNT> eosfilestore <PUBLIC KEY> "active" -p <ACCOUNT>@active
$ cleos set action permission <ACCOUNT> eosfilestore upload eosfilestore
```

## Default .eosfilestore/config.json

```
{
  "from":"ACCOUNT",
  "privateKey":"WIF",
  "permssion":"active"
}
```

## Custom Permission

```
{
  "from":"ACCOUNT",
  "privateKey":"WIF",
  "permssion":"eosfilestore"
}
```